### PR TITLE
Remove duplicate annotations

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -7,21 +7,6 @@ on:
 name: Check and Lint
 
 jobs:
-  check:
-    name: Check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - name: Cargo check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,10 +18,7 @@ jobs:
         toolchain: stable
         override: true
     - name: Cargo install deps
-      uses: actions-rs/cargo@v1
-      with:
-        command: install
-        args: cargo2junit
+      run: cargo install cargo2junit
     - name: Cargo test
       run: cargo test -- -Z unstable-options --format json --report-time | cargo2junit > results.xml
     - name: Publish Test Results


### PR DESCRIPTION
Removed or disabled some annotations so that only Clippy sets `cargo check` annotations
ie no more: 
![image](https://user-images.githubusercontent.com/28459732/145364555-70884623-a0d0-45d1-b94d-b4ea96c3f509.png)
